### PR TITLE
o Need assignment of A even if it is not given

### DIFF
--- a/snopt7/snopt_solver.py
+++ b/snopt7/snopt_solver.py
@@ -190,6 +190,7 @@ class SNOPT_solver(object):
             A      = usrA.data
             neA    = usrA.nnz
         else:
+            A      = None
             if verbose:
                 print ' --> Linear component of Jacobian not provided'
 


### PR DESCRIPTION
snopt-python generates a Python error when A is not explicitly given

Traceback (most recent call last):
  File "/Users/name/Library/Python/2.7/lib/python/site-packages/optimize/snopt7/snopt_solver.py", line 426, in snopta
    iAfun, jAvar, neA, A, iGfun, jGvar, neG,\
UnboundLocalError: local variable 'A' referenced before assignment

This correction simply assigns "A = None" if A is not given (usrA is not of known type).  I hope that it can be applied so that I can delete my fork.

Thanks in advance,

Bill
w.t.jones@nasa.gov
